### PR TITLE
Added Score to Speech Module's completion page

### DIFF
--- a/lib/widgets/module/module_widget.dart
+++ b/lib/widgets/module/module_widget.dart
@@ -9,6 +9,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:hearbat/utils/google_tts_util.dart';
 import 'word_missed_button_widget.dart';
 import 'package:confetti/confetti.dart';
+import 'score_widget.dart';
 
 class ModuleWidget extends StatefulWidget {
   final String title;
@@ -293,7 +294,8 @@ class _ModulePageState extends State<ModuleWidget> {
             // Today's score
             ScoreWidget(
               context: context,
-              correctAnswersCount: correctAnswersCount,
+              type: ScoreType.score,
+              correctAnswersCount: correctAnswersCount.toString(),
               subtitleText: "Score",
               icon: Icon(
                 Icons.star,
@@ -305,7 +307,8 @@ class _ModulePageState extends State<ModuleWidget> {
             ),
             ScoreWidget(
               context: context,
-              correctAnswersCount: correctAnswersCount,
+              type: ScoreType.score,
+              correctAnswersCount: correctAnswersCount.toString(),
               subtitleText: "Highest Score",
               icon: Icon(
                 Icons.emoji_events,
@@ -348,113 +351,6 @@ class _ModulePageState extends State<ModuleWidget> {
           ],
         ),
       ],
-    );
-  }
-}
-
-var gradientBoxDecoration = BoxDecoration(
-  gradient: LinearGradient(
-    begin: Alignment.topCenter,
-    end: Alignment.bottomCenter,
-    colors: [
-      Color.fromARGB(255, 248, 213, 245),
-      Color.fromARGB(255, 255, 192, 199),
-      Color.fromARGB(255, 213, 177, 239),
-    ],
-  ),
-  borderRadius: BorderRadius.circular(8.0),
-  border: Border.all(
-    color: Color.fromARGB(255, 7, 45, 78),
-    width: 3.0,
-  ),
-  boxShadow: [
-    BoxShadow(
-      color: Colors.grey.withAlpha((0.5 * 255).toInt()),
-      spreadRadius: 5,
-      blurRadius: 7,
-      offset: Offset(0, 3),
-    ),
-  ],
-);
-
-var blueBoxDecoration = BoxDecoration(
-  color: Color.fromARGB(255, 7, 45, 78),
-  borderRadius: BorderRadius.circular(8.0),
-  border: Border.all(
-    color: Color.fromARGB(255, 7, 45, 78),
-    width: 3.0,
-  ),
-  boxShadow: [
-    BoxShadow(
-      color: Colors.grey.withAlpha((0.5 * 255).toInt()),
-      spreadRadius: 5,
-      blurRadius: 7,
-      offset: Offset(0, 3),
-    ),
-  ],
-);
-
-
-class ScoreWidget extends StatelessWidget {
-  const ScoreWidget(
-      {super.key,
-      required this.context,
-      required this.correctAnswersCount,
-      required this.subtitleText,
-      required this.icon,
-      required this.boxDecoration,
-      required this.total});
-
-  final BuildContext context;
-  final int correctAnswersCount;
-  final String subtitleText;
-  final Icon icon;
-  final BoxDecoration boxDecoration;
-  final int total;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: MediaQuery.of(context).size.width * .90,
-      height: MediaQuery.of(context).size.height * .1,
-      margin: EdgeInsets.fromLTRB(20.0, 20.0, 20.0, 10.0),
-      padding: EdgeInsets.all(8.0),
-      decoration: boxDecoration,
-      child: Stack(
-        children: [
-          Positioned(
-            left: 10,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                AutoSizeText(
-                  '$correctAnswersCount / $total',
-                  style: TextStyle(
-                      fontSize: 25,
-                      fontWeight: FontWeight.w900,
-                      color: subtitleText == "Highest Score"
-                          ? Colors.white
-                          : Color.fromARGB(255, 7, 45, 78)),
-                ),
-                AutoSizeText(
-                  subtitleText,
-                  style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w900,
-                      color: subtitleText == "Highest Score"
-                          ? Colors.white
-                          : Color.fromARGB(255, 7, 45, 78)),
-                ),
-              ],
-            ),
-          ),
-          Positioned(
-            top: 10,
-            right: 10,
-            child: icon,
-          ),
-        ],
-      ),
     );
   }
 }

--- a/lib/widgets/module/score_widget.dart
+++ b/lib/widgets/module/score_widget.dart
@@ -1,0 +1,115 @@
+import 'package:auto_size_text/auto_size_text.dart';
+import 'package:flutter/material.dart';
+
+enum ScoreType { score, average }
+
+class ScoreWidget extends StatelessWidget {
+  const ScoreWidget(
+      {super.key,
+        required this.context,
+        required this.type,
+        required this.correctAnswersCount,
+        required this.subtitleText,
+        required this.icon,
+        required this.boxDecoration,
+        required this.total});
+
+  final BuildContext context;
+  final ScoreType type;
+  final String correctAnswersCount;
+  final String subtitleText;
+  final Icon icon;
+  final BoxDecoration boxDecoration;
+  final int total;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: MediaQuery.of(context).size.width * .90,
+      height: MediaQuery.of(context).size.height * .1,
+      margin: EdgeInsets.fromLTRB(20.0, 20.0, 20.0, 10.0),
+      padding: EdgeInsets.all(8.0),
+      decoration: boxDecoration,
+      child: Stack(
+        children: [
+          Positioned(
+            left: 10,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                AutoSizeText(
+                  switch (type) {
+                    ScoreType.score => '$correctAnswersCount / $total',
+                    ScoreType.average => '$correctAnswersCount%'
+                  },
+                  style: TextStyle(
+                      fontSize: 25,
+                      fontWeight: FontWeight.w900,
+                      color: subtitleText.contains("Highest")
+                          ? Colors.white
+                          : Color.fromARGB(255, 7, 45, 78)),
+                ),
+                AutoSizeText(
+                  subtitleText,
+                  style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w900,
+                      color: subtitleText.contains("Highest")
+                          ? Colors.white
+                          : Color.fromARGB(255, 7, 45, 78)),
+                ),
+              ],
+            ),
+          ),
+          Positioned(
+            top: 10,
+            right: 10,
+            child: icon,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+var gradientBoxDecoration = BoxDecoration(
+  gradient: LinearGradient(
+    begin: Alignment.topCenter,
+    end: Alignment.bottomCenter,
+    colors: [
+      Color.fromARGB(255, 248, 213, 245),
+      Color.fromARGB(255, 255, 192, 199),
+      Color.fromARGB(255, 213, 177, 239),
+    ],
+  ),
+  borderRadius: BorderRadius.circular(8.0),
+  border: Border.all(
+    color: Color.fromARGB(255, 7, 45, 78),
+    width: 3.0,
+  ),
+  boxShadow: [
+    BoxShadow(
+      color: Colors.grey.withAlpha((0.5 * 255).toInt()),
+      spreadRadius: 5,
+      blurRadius: 7,
+      offset: Offset(0, 3),
+    ),
+  ],
+);
+
+var blueBoxDecoration = BoxDecoration(
+  color: Color.fromARGB(255, 7, 45, 78),
+  borderRadius: BorderRadius.circular(8.0),
+  border: Border.all(
+    color: Color.fromARGB(255, 7, 45, 78),
+    width: 3.0,
+  ),
+  boxShadow: [
+    BoxShadow(
+      color: Colors.grey.withAlpha((0.5 * 255).toInt()),
+      spreadRadius: 5,
+      blurRadius: 7,
+      offset: Offset(0, 3),
+    ),
+  ],
+);

--- a/lib/widgets/module/speech_module_widget.dart
+++ b/lib/widgets/module/speech_module_widget.dart
@@ -32,6 +32,7 @@ class SpeechModuleWidgetState extends State<SpeechModuleWidget> {
   String _sentence = '';
   double _grade = 0.0;
   double _gradeSum = 0.0;
+  int _attempts = 0;
   String voiceType = '';
   bool _isSubmitted = false;
   bool _isCompleted = false;
@@ -136,7 +137,6 @@ class SpeechModuleWidgetState extends State<SpeechModuleWidget> {
         setState(() {
           _transcription = transcription;
           _grade = grade;
-          _gradeSum += grade;
           _isSubmitted = true;
         });
       } catch (e) {
@@ -156,6 +156,8 @@ class SpeechModuleWidgetState extends State<SpeechModuleWidget> {
 
   void _submitRecording() {
     setState(() {
+      _gradeSum += _grade;
+      _attempts++;
       _isCheckPressed = !_isCheckPressed;
       if (_isCheckPressed == false) {
         currentSentenceIndex++;
@@ -358,7 +360,7 @@ class SpeechModuleWidgetState extends State<SpeechModuleWidget> {
             // Today's score
             ScoreWidget(
               context: context,
-              averageGrade: _gradeSum / 100.0,
+              averageGrade: (_gradeSum / _attempts).toStringAsFixed(2),
               subtitleText: "Score",
               icon: Icon(
                 Icons.star,
@@ -366,11 +368,11 @@ class SpeechModuleWidgetState extends State<SpeechModuleWidget> {
                 size: 30,
               ),
               boxDecoration: gradientBoxDecoration,
-              totalGrade: 100, // editting
+              totalGrade: 100, // editing
             ),
             ScoreWidget(
               context: context,
-              averageGrade: _gradeSum / 100.0,
+              averageGrade: (_gradeSum / _attempts).toStringAsFixed(2),
               subtitleText: "Highest Score",
               icon: Icon(
                 Icons.emoji_events,
@@ -378,7 +380,7 @@ class SpeechModuleWidgetState extends State<SpeechModuleWidget> {
                 size: 30,
               ),
               boxDecoration: blueBoxDecoration,
-              totalGrade: 100, // editting
+              totalGrade: 100, // editing
             ),
             Padding(
               padding: const EdgeInsets.only(top: 40.0, bottom: 40.0),
@@ -511,7 +513,7 @@ class ScoreWidget extends StatelessWidget {
         required this.totalGrade});
 
   final BuildContext context;
-  final double averageGrade;
+  final String averageGrade;
   final String subtitleText;
   final Icon icon;
   final BoxDecoration boxDecoration;

--- a/lib/widgets/module/speech_module_widget.dart
+++ b/lib/widgets/module/speech_module_widget.dart
@@ -31,6 +31,7 @@ class SpeechModuleWidgetState extends State<SpeechModuleWidget> {
   String _transcription = '';
   String _sentence = '';
   double _grade = 0.0;
+  double _gradeSum = 0.0;
   String voiceType = '';
   bool _isSubmitted = false;
   bool _isCompleted = false;
@@ -135,6 +136,7 @@ class SpeechModuleWidgetState extends State<SpeechModuleWidget> {
         setState(() {
           _transcription = transcription;
           _grade = grade;
+          _gradeSum += grade;
           _isSubmitted = true;
         });
       } catch (e) {
@@ -333,50 +335,116 @@ class SpeechModuleWidgetState extends State<SpeechModuleWidget> {
             Colors.green
           ],
         ),
-        Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Spacer(flex: 1),
-              Expanded(
-                child: Padding(
-                  padding: const EdgeInsets.fromLTRB(20.0, 20.0, 20.0, 10.0),
-                  child: AutoSizeText(
-                    'Good Job Completing the Module!',
-                    maxLines: 3,
-                    style: TextStyle(
-                        fontSize: 40,
-                        fontWeight: FontWeight.bold,
-                        color: Color.fromARGB(255, 7, 45, 78)),
-                    textAlign: TextAlign.center,
+        Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Padding(
+              padding:
+                const EdgeInsets.only(left: 120.0, right: 120.0, top: 60.0),
+              child: Image.asset("assets/visuals/HBCompletion.png", fit: BoxFit.contain),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(20.0, 10.0, 20.0, 0.0),
+              child: AutoSizeText(
+                'Lesson Complete!',
+                maxLines: 1,
+                style: TextStyle(
+                    fontSize: 32,
+                    fontWeight: FontWeight.bold,
+                    color: Color.fromARGB(255, 7, 45, 78)),
+                textAlign: TextAlign.center,
+              ),
+            ),
+            // Today's score
+            ScoreWidget(
+              context: context,
+              averageGrade: _gradeSum / 100.0,
+              subtitleText: "Score",
+              icon: Icon(
+                Icons.star,
+                color: Color.fromARGB(255, 7, 45, 78),
+                size: 30,
+              ),
+              boxDecoration: gradientBoxDecoration,
+              totalGrade: 100, // editting
+            ),
+            ScoreWidget(
+              context: context,
+              averageGrade: _gradeSum / 100.0,
+              subtitleText: "Highest Score",
+              icon: Icon(
+                Icons.emoji_events,
+                color: Color.fromARGB(255, 255, 255, 255),
+                size: 30,
+              ),
+              boxDecoration: blueBoxDecoration,
+              totalGrade: 100, // editting
+            ),
+            Padding(
+              padding: const EdgeInsets.only(top: 40.0, bottom: 40.0),
+              child: ElevatedButton(
+                onPressed: () => Navigator.pop(context),
+                style: ElevatedButton.styleFrom(
+                  padding: EdgeInsets.symmetric(horizontal: 40, vertical: 20),
+                  shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(10.0)),
+                ),
+                child: AutoSizeText(
+                  'Return to Path',
+                  maxLines: 1,
+                  style: TextStyle(
+                      fontSize: 20, color: Color.fromARGB(255, 7, 45, 78)
                   ),
                 ),
               ),
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 30.0),
-                child: Image.asset("assets/visuals/HBCompletion.png",
-                    fit: BoxFit.contain),
-              ),
-              Padding(
-                padding: const EdgeInsets.only(top: 40.0, bottom: 40.0),
-                child: ElevatedButton(
-                  onPressed: () => Navigator.pop(context),
-                  style: ElevatedButton.styleFrom(
-                    padding: EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-                    shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(10.0)),
-                  ),
-                  child: AutoSizeText(
-                    'Return to Path',
-                    maxLines: 1,
-                    style: TextStyle(
-                        fontSize: 20, color: Color.fromARGB(255, 7, 45, 78)),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
+            ),
+          ]
+        )
+
+        //Center(
+        //  child: Column(
+        //    mainAxisAlignment: MainAxisAlignment.center,
+        //    children: [
+        //      Spacer(flex: 1),
+        //      Expanded(
+        //        child: Padding(
+        //          padding: const EdgeInsets.fromLTRB(20.0, 20.0, 20.0, 10.0),
+        //          child: AutoSizeText(
+        //            'Good Job Completing the Module!',
+        //            maxLines: 3,
+        //            style: TextStyle(
+        //                fontSize: 40,
+        //                fontWeight: FontWeight.bold,
+        //                color: Color.fromARGB(255, 7, 45, 78)),
+        //            textAlign: TextAlign.center,
+        //          ),
+        //        ),
+        //      ),
+        //      Padding(
+        //        padding: const EdgeInsets.symmetric(horizontal: 30.0),
+        //        child: Image.asset("assets/visuals/HBCompletion.png",
+        //            fit: BoxFit.contain),
+        //      ),
+        //      Padding(
+        //        padding: const EdgeInsets.only(top: 40.0, bottom: 40.0),
+        //        child: ElevatedButton(
+        //          onPressed: () => Navigator.pop(context),
+        //          style: ElevatedButton.styleFrom(
+        //            padding: EdgeInsets.symmetric(horizontal: 40, vertical: 20),
+        //            shape: RoundedRectangleBorder(
+        //                borderRadius: BorderRadius.circular(10.0)),
+        //          ),
+        //          child: AutoSizeText(
+        //            'Return to Path',
+        //            maxLines: 1,
+        //            style: TextStyle(
+        //                fontSize: 20, color: Color.fromARGB(255, 7, 45, 78)),
+        //          ),
+        //        ),
+        //      ),
+        //    ],
+        //  ),
+        //),
       ],
     );
   }
@@ -388,3 +456,111 @@ class SpeechModuleWidgetState extends State<SpeechModuleWidget> {
     _confettiController.dispose();
   }
 }
+
+var gradientBoxDecoration = BoxDecoration(
+  gradient: LinearGradient(
+    begin: Alignment.topCenter,
+    end: Alignment.bottomCenter,
+    colors: [
+      Color.fromARGB(255, 248, 213, 245),
+      Color.fromARGB(255, 255, 192, 199),
+      Color.fromARGB(255, 213, 177, 239),
+    ],
+  ),
+  borderRadius: BorderRadius.circular(8.0),
+  border: Border.all(
+    color: Color.fromARGB(255, 7, 45, 78),
+    width: 3.0,
+  ),
+  boxShadow: [
+    BoxShadow(
+      color: Colors.grey.withAlpha((0.5 * 255).toInt()),
+      spreadRadius: 5,
+      blurRadius: 7,
+      offset: Offset(0, 3),
+    ),
+  ],
+);
+
+var blueBoxDecoration = BoxDecoration(
+  color: Color.fromARGB(255, 7, 45, 78),
+  borderRadius: BorderRadius.circular(8.0),
+  border: Border.all(
+    color: Color.fromARGB(255, 7, 45, 78),
+    width: 3.0,
+  ),
+  boxShadow: [
+    BoxShadow(
+      color: Colors.grey.withAlpha((0.5 * 255).toInt()),
+      spreadRadius: 5,
+      blurRadius: 7,
+      offset: Offset(0, 3),
+    ),
+  ],
+);
+
+
+class ScoreWidget extends StatelessWidget {
+  const ScoreWidget(
+      {super.key,
+        required this.context,
+        required this.averageGrade,
+        required this.subtitleText,
+        required this.icon,
+        required this.boxDecoration,
+        required this.totalGrade});
+
+  final BuildContext context;
+  final double averageGrade;
+  final String subtitleText;
+  final Icon icon;
+  final BoxDecoration boxDecoration;
+  final int totalGrade;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: MediaQuery.of(context).size.width * .90,
+      height: MediaQuery.of(context).size.height * .1,
+      margin: EdgeInsets.fromLTRB(20.0, 20.0, 20.0, 10.0),
+      padding: EdgeInsets.all(8.0),
+      decoration: boxDecoration,
+      child: Stack(
+        children: [
+          Positioned(
+            left: 10,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                AutoSizeText(
+                  '$averageGrade% / $totalGrade%',
+                  style: TextStyle(
+                      fontSize: 25,
+                      fontWeight: FontWeight.w900,
+                      color: subtitleText == "Highest Score"
+                          ? Colors.white
+                          : Color.fromARGB(255, 7, 45, 78)),
+                ),
+                AutoSizeText(
+                  subtitleText,
+                  style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.w900,
+                      color: subtitleText == "Highest Score"
+                          ? Colors.white
+                          : Color.fromARGB(255, 7, 45, 78)),
+                ),
+              ],
+            ),
+          ),
+          Positioned(
+            top: 10,
+            right: 10,
+            child: icon,
+          ),
+        ],
+      ),
+    );
+  }
+}
+

--- a/lib/widgets/module/speech_module_widget.dart
+++ b/lib/widgets/module/speech_module_widget.dart
@@ -386,70 +386,31 @@ class SpeechModuleWidgetState extends State<SpeechModuleWidget> {
               total: 100, // editing
             ),
             Padding(
-              padding: const EdgeInsets.only(top: 40.0, bottom: 40.0),
+              padding: const EdgeInsets.only(
+                  top: 40.0, bottom: 40.0, left: 20, right: 20),
               child: ElevatedButton(
-                onPressed: () => Navigator.pop(context),
+                onPressed: () =>
+                  Navigator.pop(context),
                 style: ElevatedButton.styleFrom(
-                  padding: EdgeInsets.symmetric(horizontal: 40, vertical: 20),
+                  backgroundColor: Color.fromARGB(255, 94, 224, 82),
                   shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(10.0)),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  minimumSize: Size(400, 50),
+                  elevation: 5,
                 ),
-                child: AutoSizeText(
-                  'Return to Path',
-                  maxLines: 1,
+                child: Text(
+                  'CONTINUE',
                   style: TextStyle(
-                      fontSize: 20, color: Color.fromARGB(255, 7, 45, 78)
+                    color: const Color.fromARGB(255, 255, 255, 255),
+                    fontSize: 20,
+                    fontWeight: FontWeight.w600,
                   ),
                 ),
               ),
             ),
           ]
         )
-
-        //Center(
-        //  child: Column(
-        //    mainAxisAlignment: MainAxisAlignment.center,
-        //    children: [
-        //      Spacer(flex: 1),
-        //      Expanded(
-        //        child: Padding(
-        //          padding: const EdgeInsets.fromLTRB(20.0, 20.0, 20.0, 10.0),
-        //          child: AutoSizeText(
-        //            'Good Job Completing the Module!',
-        //            maxLines: 3,
-        //            style: TextStyle(
-        //                fontSize: 40,
-        //                fontWeight: FontWeight.bold,
-        //                color: Color.fromARGB(255, 7, 45, 78)),
-        //            textAlign: TextAlign.center,
-        //          ),
-        //        ),
-        //      ),
-        //      Padding(
-        //        padding: const EdgeInsets.symmetric(horizontal: 30.0),
-        //        child: Image.asset("assets/visuals/HBCompletion.png",
-        //            fit: BoxFit.contain),
-        //      ),
-        //      Padding(
-        //        padding: const EdgeInsets.only(top: 40.0, bottom: 40.0),
-        //        child: ElevatedButton(
-        //          onPressed: () => Navigator.pop(context),
-        //          style: ElevatedButton.styleFrom(
-        //            padding: EdgeInsets.symmetric(horizontal: 40, vertical: 20),
-        //            shape: RoundedRectangleBorder(
-        //                borderRadius: BorderRadius.circular(10.0)),
-        //          ),
-        //          child: AutoSizeText(
-        //            'Return to Path',
-        //            maxLines: 1,
-        //            style: TextStyle(
-        //                fontSize: 20, color: Color.fromARGB(255, 7, 45, 78)),
-        //          ),
-        //        ),
-        //      ),
-        //    ],
-        //  ),
-        //),
       ],
     );
   }

--- a/lib/widgets/module/speech_module_widget.dart
+++ b/lib/widgets/module/speech_module_widget.dart
@@ -10,6 +10,7 @@ import 'module_progress_bar_widget.dart';
 import 'check_button_widget.dart';
 import 'package:confetti/confetti.dart';
 import 'dart:math';
+import 'score_widget.dart';
 
 class SpeechModuleWidget extends StatefulWidget {
   final String chapter;
@@ -360,27 +361,29 @@ class SpeechModuleWidgetState extends State<SpeechModuleWidget> {
             // Today's score
             ScoreWidget(
               context: context,
-              averageGrade: (_gradeSum / _attempts).toStringAsFixed(2),
-              subtitleText: "Score",
+              type: ScoreType.average,
+              correctAnswersCount: (_gradeSum / _attempts).toStringAsFixed(2),
+              subtitleText: "Average Accuracy",
               icon: Icon(
                 Icons.star,
                 color: Color.fromARGB(255, 7, 45, 78),
                 size: 30,
               ),
               boxDecoration: gradientBoxDecoration,
-              totalGrade: 100, // editing
+              total: 100, // editing
             ),
             ScoreWidget(
               context: context,
-              averageGrade: (_gradeSum / _attempts).toStringAsFixed(2),
-              subtitleText: "Highest Score",
+              type: ScoreType.average,
+              correctAnswersCount: (_gradeSum / _attempts).toStringAsFixed(2),
+              subtitleText: "Highest Average Accuracy",
               icon: Icon(
                 Icons.emoji_events,
                 color: Color.fromARGB(255, 255, 255, 255),
                 size: 30,
               ),
               boxDecoration: blueBoxDecoration,
-              totalGrade: 100, // editing
+              total: 100, // editing
             ),
             Padding(
               padding: const EdgeInsets.only(top: 40.0, bottom: 40.0),
@@ -458,111 +461,3 @@ class SpeechModuleWidgetState extends State<SpeechModuleWidget> {
     _confettiController.dispose();
   }
 }
-
-var gradientBoxDecoration = BoxDecoration(
-  gradient: LinearGradient(
-    begin: Alignment.topCenter,
-    end: Alignment.bottomCenter,
-    colors: [
-      Color.fromARGB(255, 248, 213, 245),
-      Color.fromARGB(255, 255, 192, 199),
-      Color.fromARGB(255, 213, 177, 239),
-    ],
-  ),
-  borderRadius: BorderRadius.circular(8.0),
-  border: Border.all(
-    color: Color.fromARGB(255, 7, 45, 78),
-    width: 3.0,
-  ),
-  boxShadow: [
-    BoxShadow(
-      color: Colors.grey.withAlpha((0.5 * 255).toInt()),
-      spreadRadius: 5,
-      blurRadius: 7,
-      offset: Offset(0, 3),
-    ),
-  ],
-);
-
-var blueBoxDecoration = BoxDecoration(
-  color: Color.fromARGB(255, 7, 45, 78),
-  borderRadius: BorderRadius.circular(8.0),
-  border: Border.all(
-    color: Color.fromARGB(255, 7, 45, 78),
-    width: 3.0,
-  ),
-  boxShadow: [
-    BoxShadow(
-      color: Colors.grey.withAlpha((0.5 * 255).toInt()),
-      spreadRadius: 5,
-      blurRadius: 7,
-      offset: Offset(0, 3),
-    ),
-  ],
-);
-
-
-class ScoreWidget extends StatelessWidget {
-  const ScoreWidget(
-      {super.key,
-        required this.context,
-        required this.averageGrade,
-        required this.subtitleText,
-        required this.icon,
-        required this.boxDecoration,
-        required this.totalGrade});
-
-  final BuildContext context;
-  final String averageGrade;
-  final String subtitleText;
-  final Icon icon;
-  final BoxDecoration boxDecoration;
-  final int totalGrade;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: MediaQuery.of(context).size.width * .90,
-      height: MediaQuery.of(context).size.height * .1,
-      margin: EdgeInsets.fromLTRB(20.0, 20.0, 20.0, 10.0),
-      padding: EdgeInsets.all(8.0),
-      decoration: boxDecoration,
-      child: Stack(
-        children: [
-          Positioned(
-            left: 10,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                AutoSizeText(
-                  '$averageGrade% / $totalGrade%',
-                  style: TextStyle(
-                      fontSize: 25,
-                      fontWeight: FontWeight.w900,
-                      color: subtitleText == "Highest Score"
-                          ? Colors.white
-                          : Color.fromARGB(255, 7, 45, 78)),
-                ),
-                AutoSizeText(
-                  subtitleText,
-                  style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w900,
-                      color: subtitleText == "Highest Score"
-                          ? Colors.white
-                          : Color.fromARGB(255, 7, 45, 78)),
-                ),
-              ],
-            ),
-          ),
-          Positioned(
-            top: 10,
-            right: 10,
-            child: icon,
-          ),
-        ],
-      ),
-    );
-  }
-}
-


### PR DESCRIPTION
[HB-34](https://psu-capstone-2025.atlassian.net/browse/HB-34?atlOrigin=eyJpIjoiNjAwZDI4NDFlYTBiNDY0ZjhiZWU2OWY0YjMwY2FmODMiLCJwIjoiaiJ9)
- Moved ScoreWidget to score_widget.dart for use by all modules
  - New ScoreType enum 'type' field dictates appearance of final score page
- Swapped speech button to 'CONTINUE' as on other module completions

Here is a screenshot of the new completion screen:


![image](https://github.com/user-attachments/assets/708582da-8f60-44cb-8fcf-640184fe9004)




[HB-34]: https://psu-capstone-2025.atlassian.net/browse/HB-34?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ