### PR TITLE
HB-60/have unsaved changes state update when you save

### DIFF
--- a/lib/pages/module_types/custom/custom_path.dart
+++ b/lib/pages/module_types/custom/custom_path.dart
@@ -1,4 +1,3 @@
-import 'package:dotted_border/dotted_border.dart';
 import 'package:flutter/material.dart';
 import 'package:hearbat/widgets/edit_custom_module.dart';
 import 'package:hearbat/widgets/path/difficulty_selection_widget.dart';
@@ -93,37 +92,46 @@ class CustomPathState extends State<CustomPath> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: TopBar(
-        title: "Custom Modules",
+        title: "Custom Module Builder",
       ),
       body: SingleChildScrollView(
         child: Column(
           children: <Widget>[
             Padding(
-                padding: const EdgeInsets.fromLTRB(20.0, 20.0, 20.0, 20.0),
-                child: DottedBorder(
-                  dashPattern: [6, 6],
-                  borderType: BorderType.RRect,
-                  radius: Radius.circular(8),
-                  color: Color.fromARGB(255, 35, 102, 29),
-                  strokeWidth: 2,
-                  child: ElevatedButton(
-                      onPressed: _navigateToCreateModule,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Color.fromARGB(255, 94, 224, 82),
-                        padding: EdgeInsets.symmetric(
-                          vertical: 20.0,
-                        ),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        textStyle: TextStyle(fontSize: 24.0),
-                        minimumSize: Size(double.infinity, 40),
-                      ),
-                      child: Text("Create New Module",
-                          style: TextStyle(
-                              fontWeight: FontWeight.bold,
-                              color: Color.fromARGB(255, 255, 255, 255)))),
-                )),
+              padding: const EdgeInsets.all(20.0),
+              child: Container(
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(8),
+                  boxShadow: [
+                    BoxShadow(
+                      color: Color.fromRGBO(0, 0, 0, 0.4), // 10% opacity black
+                      offset: Offset(0, 4), // just 2px down
+                      blurRadius: 4, // softer blur
+                    ),
+                  ],
+                ),
+                child: ElevatedButton(
+                  onPressed: _navigateToCreateModule,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Color.fromARGB(255, 123, 225, 114),
+                    padding: EdgeInsets.symmetric(vertical: 22.0),
+                    shape: RoundedRectangleBorder(
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    textStyle: TextStyle(fontSize: 22.0),
+                    minimumSize: Size(double.infinity, 40),
+                    elevation: 0, // remove the default material shadow
+                  ),
+                  child: Text(
+                    "Create Module",
+                    style: TextStyle(
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ),
+            ),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 20.0),
               child: GridView.builder(

--- a/lib/widgets/custom_module_card_widget.dart
+++ b/lib/widgets/custom_module_card_widget.dart
@@ -3,104 +3,135 @@ import 'package:flutter/material.dart';
 class CustomModuleCard extends StatelessWidget {
   final String moduleName;
   final VoidCallback onStart;
-  final VoidCallback onDelete;
   final VoidCallback onEdit;
+  final VoidCallback onDelete;
 
   const CustomModuleCard({
     super.key,
     required this.moduleName,
     required this.onStart,
-    required this.onDelete,
     required this.onEdit,
+    required this.onDelete,
   });
 
   @override
   Widget build(BuildContext context) {
     return Card(
-      margin: EdgeInsets.symmetric(horizontal: 8, vertical: 8),
-      child: SizedBox(
-        width: double.infinity,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: <Widget>[
-            // Header container
-            Container(
-              width: double.infinity,
-              padding: EdgeInsets.symmetric(vertical: 12),
-              decoration: BoxDecoration(
-                color: Color.fromARGB(255, 7, 45, 78),
-                borderRadius: BorderRadius.only(
-                  topLeft: Radius.circular(12.0),
-                  topRight: Radius.circular(12.0),
-                ),
-              ),
-              child: Text(
-                moduleName,
-                style: TextStyle(
-                  fontSize: 16.0,
-                  fontWeight: FontWeight.bold,
-                  color: Colors.white,
-                ),
-                textAlign: TextAlign.center,
+      elevation: 2,
+      margin: const EdgeInsets.fromLTRB(0,30,0,0), // less bottom space
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min, // wrap content
+        children: [
+          // ─── HEADER ─────────────────────────────
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            decoration: const BoxDecoration(
+              color: Color.fromARGB(255, 7, 45, 78),
+              borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+            ),
+            child: Text(
+              moduleName,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                color: Colors.white,
+                fontSize: 18,
+                fontWeight: FontWeight.bold,
               ),
             ),
-            // Buttons container
-            Padding(
-              padding: const EdgeInsets.fromLTRB(10.0, 10.0, 10.0, 10.0),
-              child: Column(
-                mainAxisSize: MainAxisSize.min,
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: <Widget>[
-                  SizedBox(
-                    height: 36,
-                    child: ElevatedButton(
-                      onPressed: onStart,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Color.fromARGB(255, 154, 107, 187),
-                        foregroundColor: Colors.white,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
-                        ),
+          ),
+      
+          // ─── BUTTON GROUP ───────────────────────
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 24, 16, 8), // trimmed bottom
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                // START button
+                SizedBox(
+                  width: 140,
+                  height: 40,
+                  child: ElevatedButton(
+                    onPressed: onStart,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Color.fromARGB(255, 123, 225, 114),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(8),
                       ),
-                      child: Text('Start', style: TextStyle(fontSize: 14)),
+                      padding: EdgeInsets.zero,
+                    ),
+                    child: const Text(
+                      'START',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 14,
+                        letterSpacing: 0.8,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
                   ),
-                  SizedBox(height: 8),
-                  SizedBox(
-                    height: 36,
-                    child: ElevatedButton(
-                      onPressed: onEdit,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Color.fromARGB(255, 154, 187, 154),
-                        foregroundColor: Colors.white,
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
+                ),
+      
+                const SizedBox(height: 12),
+      
+                // EDIT & DELETE row, same total width as START
+                SizedBox(
+                  width: 140,
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: SizedBox(
+                          height: 40,
+                          child: ElevatedButton(
+                            onPressed: onEdit,
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: const Color.fromARGB(255, 7, 45, 78),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              padding: EdgeInsets.zero,
+                            ),
+                            child: const Icon(
+                              Icons.edit,
+                              color: Colors.white,
+                              size: 20,
+                            ),
+                          ),
                         ),
                       ),
-                      child: Text('Edit', style: TextStyle(fontSize: 14)),
-                    ),
-                  ),
-                  SizedBox(height: 8),
-                  SizedBox(
-                    height: 36,
-                    child: ElevatedButton(
-                      onPressed: onDelete,
-                      style: ElevatedButton.styleFrom(
-                        backgroundColor: Color.fromARGB(255, 214, 214, 214),
-                        shape: RoundedRectangleBorder(
-                          borderRadius: BorderRadius.circular(8),
+      
+                      const SizedBox(width: 12),
+      
+                      Expanded(
+                        child: SizedBox(
+                          height: 40,
+                          child: ElevatedButton(
+                            onPressed: onDelete,
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: const Color.fromARGB(255, 7, 45, 78),
+                              shape: RoundedRectangleBorder(
+                                borderRadius: BorderRadius.circular(8),
+                              ),
+                              padding: EdgeInsets.zero,
+                            ),
+                            child: const Icon(
+                              Icons.delete,
+                              color: Colors.white,
+                              size: 20,
+                            ),
+                          ),
                         ),
-                        padding: EdgeInsets.zero,
                       ),
-                      child: Icon(Icons.delete,
-                          color: Color.fromARGB(255, 100, 100, 100), size: 20),
-                    ),
+                    ],
                   ),
-                ],
-              ),
+                ),
+              ],
             ),
-          ],
-        ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
- Made unsaved changes warning get removed in scaffold when you save
- Also made it so if you start changing something and then you change your mind and revert back to the original word it gets rid of the warning 

Note: This warning is probably unnecessary, I think when the UI gets designed for this it will be better if we had a prominent save button with no warning, and ONLY if they leave without saving it will give them two choices
1. Leave and discard all changes
2. Cancel and Keep editing

Keep saving to 1 location

But this PR is still useful

https://ux.stackexchange.com/questions/93927/save-cancel-dialog-from-pressing-cancel  

![image](https://github.com/user-attachments/assets/bb9e6401-fdae-4a84-bb7d-d751fef60bc7)


Custom UI, Add set button is weird gonna figure it out later

![image](https://github.com/user-attachments/assets/5a58b74c-439f-4534-bb22-c22ebc4e951f)
![image](https://github.com/user-attachments/assets/2efa3828-a6ce-4423-bd14-95531c5cd9d9)
![image](https://github.com/user-attachments/assets/93aa0304-df71-4f38-9d02-9092cfd5d964)

